### PR TITLE
Comparison === not working currently, change to ==

### DIFF
--- a/app/widgets/com.orthlieb.combobox/controllers/widget.js
+++ b/app/widgets/com.orthlieb.combobox/controllers/widget.js
@@ -47,7 +47,9 @@ Object.defineProperty($, "id", {
                 var rows = [], i, count = -1, selected = -1;
                 for (i in $.choices) {
                     count++;
-                    if ($._id === i) {
+                    // Do not use ===, it's probable that $._id will be treated as string, 
+                    // so $._id will be different than i (integer)
+                    if ($._id == i) {
                         // Found the selected item.
                         selected = count;
                     }


### PR DESCRIPTION
In my Android projects, I can't set id on combos, because comparison is always false.

This happens, presumable, because $._id is treated as string and i is an integer, so === doesn't match.
